### PR TITLE
feat(minio): add s3_force_path_style parameters for bucket on minio

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ type s3Config struct {
 	UploadFilePath   string `yaml:"upload_file_path"`
 	APIKey           string `yaml:"api_key"`
 	APISecret        string `yaml:"secret_access_key"`
+	S3ForcePathStyle bool   `yaml:"s3_force_path_style"`
 }
 
 // Config -
@@ -83,6 +84,10 @@ func (c *s3Config) validate() error {
 	}
 	if len(c.APISecret) == 0 {
 		return fmt.Errorf("missing mandatory key s3.api_secret")
+	}
+	// Default S3ForcePathStyle to false if not provided
+	if !c.S3ForcePathStyle {
+		c.S3ForcePathStyle = false
 	}
 	return nil
 }

--- a/manager.go
+++ b/manager.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -11,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	log "github.com/sirupsen/logrus"
-	"os"
 )
 
 type Manager struct {
@@ -54,6 +55,7 @@ func (m *Manager) newSession() (*session.Session, error) {
 	config.WithRegion(m.config.S3.Region)
 	config.WithEndpoint(m.config.S3.URL)
 	config.WithMaxRetries(3)
+	config.WithS3ForcePathStyle(*aws.Bool(m.config.S3.S3ForcePathStyle))
 	return session.NewSession(config)
 }
 


### PR DESCRIPTION
Hello ! 

I would like to add a minio parameters so we would be able to use this project on our minio s3 setup.

s3_force_path_style configuration to true is mandatory on minio.

by default, the parameter is equal to false.

Actually its working well.